### PR TITLE
fix(ci): build golangci-lint from source for Go 1.25 and ignore SQLite temp files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          install-mode: source
 
       - name: Vet
         run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ cmd/naeos/out/
 .env
 .env.local
 
+# SQLite temporary files
+*.db-shm
+*.db-wal
+
 # Logs
 *.log
 


### PR DESCRIPTION
Build golangci-lint from source in CI so it matches Go 1.25 target. Add SQLite temp file patterns (*.db-shm, *.db-wal) to .gitignore to avoid local artifacts in git status.