### PR TITLE
fix(governance/review): restrict license header detection to file header

### DIFF
--- a/internal/governance/review/reviewer.go
+++ b/internal/governance/review/reviewer.go
@@ -136,7 +136,22 @@ func containsPackageDecl(content string) bool {
 }
 
 func containsLicense(content string) bool {
-	return containsStr(content, "License") || containsStr(content, "license") || containsStr(content, "Apache") || containsStr(content, "MIT")
+	lines := splitLines(content)
+	maxLines := 20
+	if len(lines) < maxLines {
+		maxLines = len(lines)
+	}
+
+	header := strings.Join(lines[:maxLines], "\n")
+	licenseMarkers := []string{"license", "apache", "mit", "copyright", "licensed under"}
+	lowerHeader := strings.ToLower(header)
+
+	for _, marker := range licenseMarkers {
+		if strings.Contains(lowerHeader, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func splitLines(s string) []string {

--- a/internal/governance/review/reviewer_test.go
+++ b/internal/governance/review/reviewer_test.go
@@ -161,3 +161,30 @@ func TestReviewArtifactNoRules(t *testing.T) {
 		t.Fatalf("expected approved status, got %s", result.Status)
 	}
 }
+
+func TestReviewArtifactMissingLicenseHeader(t *testing.T) {
+	r := NewReviewer()
+	content := "package main\n\nfunc main() {}"
+	result, err := r.ReviewArtifact("test.go", content, []string{"has-license-header"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusChanges {
+		t.Fatalf("expected changes_requested status, got %s", result.Status)
+	}
+	if len(result.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(result.Comments))
+	}
+}
+
+func TestReviewArtifactHasLicenseHeader(t *testing.T) {
+	r := NewReviewer()
+	content := "// Copyright 2026 NAEOS Foundation\n// Licensed under the Apache License, Version 2.0 (the \"License\");\npackage main\n\nfunc main() {}"
+	result, err := r.ReviewArtifact("test.go", content, []string{"has-license-header"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusApproved {
+		t.Fatalf("expected approved status, got %s", result.Status)
+	}
+}


### PR DESCRIPTION
This change updates review artifact license detection to only inspect the first 20 lines of a file header. It avoids false positives from license-like text elsewhere in the file and adds tests for both missing and present header scenarios.