### PR TITLE
feat(pipeline): add Go artifact license header generation and review rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,13 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          install-mode: source
+        run: golangci-lint run ./...
 
       - name: Vet
         run: go vet ./...

--- a/internal/generation/adapters/go.go
+++ b/internal/generation/adapters/go.go
@@ -11,6 +11,14 @@ import (
 
 type GoAdapter struct{}
 
+const goLicenseHeader = `// Copyright 2026 NAEOS Foundation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+`
+
 func init() {
 	Register(GoAdapter{})
 }
@@ -49,8 +57,8 @@ func (GoAdapter) GenerateProject(projectName string) []engine.Artifact {
 		{Path: "README.md", Content: []byte(fmt.Sprintf("# %s\n\nGenerated from NAEOS pipeline (Go).\n\n## Quick Start\n\n```bash\ngo run ./cmd/app\n```\n\n## Test\n\n```bash\ngo test ./...\n```\n", projectName))},
 		{Path: "go.mod", Content: []byte(fmt.Sprintf("module github.com/example/%s\n\ngo 1.22\n\nrequire (\n\tgopkg.in/yaml.v3 v3.0.1\n)\n", slug))},
 		{Path: ".gitignore", Content: []byte("# Binaries\n*.exe\n*.exe~\n*.dll\n*.so\n*.dylib\n\n# Test binary\n*.test\n\n# Output\n*.out\n\n# Dependency\nvendor/\n\n# IDE\n.idea/\n.vscode/\n*.swp\n*.swo\n\n# OS\n.DS_Store\nThumbs.db\n")},
-		{Path: "cmd/app/main.go", Content: []byte(fmt.Sprintf("package main\n\nimport (\n\t\"fmt\"\n\t\"log\"\n\t\"net/http\"\n\n\t\"github.com/example/%s/internal/core\"\n\tcoreconfig \"github.com/example/%s/internal/core/config\"\n\tcorehttp \"github.com/example/%s/internal/core/http\"\n\tcoremiddleware \"github.com/example/%s/internal/core/middleware\"\n)\n\nfunc main() {\n\tcfg := coreconfig.Load(\"config.yaml\")\n\thandler := core.NewHandler(nil)\n\t_ = handler\n\tmux := http.NewServeMux()\n\tmux.HandleFunc(\"/\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintf(w, \"hello from %s on port %%d\", cfg.Port)\n\t})\n\tmux.HandleFunc(\"/health\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"ok\")\n\t})\n\tmux.HandleFunc(\"/api/v1\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"api v1 ready\")\n\t})\n\tmux.HandleFunc(\"/api/v1/resources\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"resources endpoint\")\n\t})\n\t_ = corehttp.Handler{}\n\twrapped := coremiddleware.LoggingMiddleware{}.Wrap(mux)\n\tlog.Printf(\"listening on :%%d\", cfg.Port)\n\tif err := http.ListenAndServe(fmt.Sprintf(\":%%d\", cfg.Port), wrapped); err != nil {\n\t\tlog.Fatal(err)\n\t}\n}\n", slug, slug, slug, slug, projectName))},
-		{Path: fmt.Sprintf("%s/package.go", pkg), Content: []byte(fmt.Sprintf("package %s\n\n// %s module.\n", pkg, projectName))},
+		{Path: "cmd/app/main.go", Content: []byte(goLicenseHeader + fmt.Sprintf("package main\n\nimport (\n\t\"fmt\"\n\t\"log\"\n\t\"net/http\"\n\n\t\"github.com/example/%s/internal/core\"\n\tcoreconfig \"github.com/example/%s/internal/core/config\"\n\tcorehttp \"github.com/example/%s/internal/core/http\"\n\tcoremiddleware \"github.com/example/%s/internal/core/middleware\"\n)\n\nfunc main() {\n\tcfg := coreconfig.Load(\"config.yaml\")\n\thandler := core.NewHandler(nil)\n\t_ = handler\n\tmux := http.NewServeMux()\n\tmux.HandleFunc(\"/\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintf(w, \"hello from %s on port %%d\", cfg.Port)\n\t})\n\tmux.HandleFunc(\"/health\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"ok\")\n\t})\n\tmux.HandleFunc(\"/api/v1\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"api v1 ready\")\n\t})\n\tmux.HandleFunc(\"/api/v1/resources\", func(w http.ResponseWriter, r *http.Request) {\n\t\t_, _ = fmt.Fprintln(w, \"resources endpoint\")\n\t})\n\t_ = corehttp.Handler{}\n\twrapped := coremiddleware.LoggingMiddleware{}.Wrap(mux)\n\tlog.Printf(\"listening on :%%d\", cfg.Port)\n\tif err := http.ListenAndServe(fmt.Sprintf(\":%%d\", cfg.Port), wrapped); err != nil {\n\t\tlog.Fatal(err)\n\t}\n}\n", slug, slug, slug, slug, projectName))},
+		{Path: fmt.Sprintf("%s/package.go", pkg), Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\n// %s module.\n", pkg, projectName))},
 		{Path: "config.yaml", Content: []byte(fmt.Sprintf("name: %s\nport: 8080\nmode: development\n", slug))},
 	}
 }
@@ -63,16 +71,16 @@ func (GoAdapter) GenerateModule(moduleName, modulePath, projectName string) []en
 	pkg := pkgName(moduleName)
 
 	return []engine.Artifact{
-		{Path: fmt.Sprintf("%s/handler.go", dir), Content: []byte(fmt.Sprintf("package %s\n\ntype Handler struct {\n\tservice Service\n}\n\nfunc NewHandler(service Service) *Handler {\n\treturn &Handler{service: service}\n}\n", pkg))},
-		{Path: fmt.Sprintf("%s/repository.go", dir), Content: []byte(fmt.Sprintf("package %s\n\ntype Repository interface {\n\tList() []string\n}\n", pkg))},
-		{Path: fmt.Sprintf("%s/service.go", dir), Content: []byte(fmt.Sprintf("package %s\n\ntype Service interface {\n\tHandle() string\n}\n", pkg))},
-		{Path: fmt.Sprintf("%s/domain/model.go", dir), Content: []byte("package domain\n\ntype Model struct {\n\tName string\n}\n")},
-		{Path: fmt.Sprintf("%s/http/handler.go", dir), Content: []byte(fmt.Sprintf("package http\n\nimport (\n\t\"encoding/json\"\n\t\"net/http\"\n)\n\ntype Handler struct{}\n\nfunc (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n\tw.Header().Set(\"Content-Type\", \"application/json\")\n\tjson.NewEncoder(w).Encode(map[string]string{\"module\": %q, \"status\": \"ok\"})\n}\n", moduleName))},
-		{Path: fmt.Sprintf("%s/http/router.go", dir), Content: []byte(fmt.Sprintf("package http\n\nimport \"net/http\"\n\ntype Router struct {\n\thandler Handler\n}\n\nfunc NewRouter() *Router {\n\treturn &Router{handler: Handler{}}\n}\n\nfunc (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {\n\tr.handler.ServeHTTP(w, req)\n}\n"))},
-		{Path: fmt.Sprintf("%s/middleware/logging.go", dir), Content: []byte("package middleware\n\nimport \"net/http\"\n\ntype LoggingMiddleware struct{}\n\nfunc (m LoggingMiddleware) Wrap(next http.Handler) http.Handler {\n\treturn http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tnext.ServeHTTP(w, r)\n\t})\n}\n")},
-		{Path: fmt.Sprintf("%s/config/config.go", dir), Content: []byte(fmt.Sprintf("package config\n\ntype Config struct {\n\tName string `yaml:\"name\"`\n\tPort int    `yaml:\"port\"`\n\tMode string `yaml:\"mode\"`\n}\n"))},
-		{Path: fmt.Sprintf("%s/config/load.go", dir), Content: []byte(fmt.Sprintf("package config\n\nimport (\n\t\"os\"\n\n\t\"gopkg.in/yaml.v3\"\n)\n\nfunc Load(path string) (*Config, error) {\n\tdata, err := os.ReadFile(path)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tvar cfg Config\n\tif err := yaml.Unmarshal(data, &cfg); err != nil {\n\t\treturn nil, err\n\t}\n\treturn &cfg, nil\n}\n"))},
-		{Path: fmt.Sprintf("%s/handler_test.go", dir), Content: []byte(fmt.Sprintf("package %s\n\nimport \"testing\"\n\nfunc TestHandler(t *testing.T) {\n\th := NewHandler(nil)\n\tif h == nil {\n\t\tt.Fatal(\"handler should not be nil\")\n\t}\n}\n", pkg))},
+		{Path: fmt.Sprintf("%s/handler.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\ntype Handler struct {\n\tservice Service\n}\n\nfunc NewHandler(service Service) *Handler {\n\treturn &Handler{service: service}\n}\n", pkg))},
+		{Path: fmt.Sprintf("%s/repository.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\ntype Repository interface {\n\tList() []string\n}\n", pkg))},
+		{Path: fmt.Sprintf("%s/service.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\ntype Service interface {\n\tHandle() string\n}\n", pkg))},
+		{Path: fmt.Sprintf("%s/domain/model.go", dir), Content: []byte(goLicenseHeader + "package domain\n\ntype Model struct {\n\tName string\n}\n")},
+		{Path: fmt.Sprintf("%s/http/handler.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package http\n\nimport (\n\t\"encoding/json\"\n\t\"net/http\"\n)\n\ntype Handler struct{}\n\nfunc (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {\n\tw.Header().Set(\"Content-Type\", \"application/json\")\n\tjson.NewEncoder(w).Encode(map[string]string{\"module\": %q, \"status\": \"ok\"})\n}\n", moduleName))},
+		{Path: fmt.Sprintf("%s/http/router.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package http\n\nimport \"net/http\"\n\ntype Router struct {\n\thandler Handler\n}\n\nfunc NewRouter() *Router {\n\treturn &Router{handler: Handler{}}\n}\n\nfunc (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {\n\tr.handler.ServeHTTP(w, req)\n}\n"))},
+		{Path: fmt.Sprintf("%s/middleware/logging.go", dir), Content: []byte(goLicenseHeader + "package middleware\n\nimport \"net/http\"\n\ntype LoggingMiddleware struct{}\n\nfunc (m LoggingMiddleware) Wrap(next http.Handler) http.Handler {\n\treturn http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tnext.ServeHTTP(w, r)\n\t})\n}\n")},
+		{Path: fmt.Sprintf("%s/config/config.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package config\n\ntype Config struct {\n\tName string `yaml:\"name\"`\n\tPort int    `yaml:\"port\"`\n\tMode string `yaml:\"mode\"`\n}\n"))},
+		{Path: fmt.Sprintf("%s/config/load.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package config\n\nimport (\n\t\"os\"\n\n\t\"gopkg.in/yaml.v3\"\n)\n\nfunc Load(path string) (*Config, error) {\n\tdata, err := os.ReadFile(path)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tvar cfg Config\n\tif err := yaml.Unmarshal(data, &cfg); err != nil {\n\t\treturn nil, err\n\t}\n\treturn &cfg, nil\n}\n"))},
+		{Path: fmt.Sprintf("%s/handler_test.go", dir), Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\nimport \"testing\"\n\nfunc TestHandler(t *testing.T) {\n\th := NewHandler(nil)\n\tif h == nil {\n\t\tt.Fatal(\"handler should not be nil\")\n\t}\n}\n", pkg))},
 	}
 }
 
@@ -89,11 +97,11 @@ func (GoAdapter) GenerateService(serviceName, serviceKind string, servicePort in
 	if serviceKind == "http" || serviceKind == "" {
 		artifacts = append(artifacts, engine.Artifact{
 			Path:    fmt.Sprintf("%s/server.go", dir),
-			Content: []byte(fmt.Sprintf("package %s\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n)\n\nfunc Run(port int) error {\n\thandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n\t\tfmt.Fprintf(w, `{\"service\":\"%%s\",\"status\":\"ok\"}`, %q)\n\t})\n\taddr := fmt.Sprintf(\":%%d\", port)\n\tfmt.Printf(\"%%s listening on %%s\\n\", %q, addr)\n\treturn http.ListenAndServe(addr, handler)\n}\n", pkg, serviceName, serviceName)),
+			Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n)\n\nfunc Run(port int) error {\n\thandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n\t\tw.Header().Set(\"Content-Type\", \"application/json\")\n\t\tfmt.Fprintf(w, \"{\\\"service\\\":\\\"%%s\\\",\\\"status\\\":\\\"ok\\\"}\", %q)\n\t})\n\taddr := fmt.Sprintf(\"%%d\", port)\n\tfmt.Printf(\"%%s listening on %%s\\n\", %q, addr)\n\treturn http.ListenAndServe(addr, handler)\n}\n", pkg, serviceName, serviceName)),
 		})
 		artifacts = append(artifacts, engine.Artifact{
 			Path:    fmt.Sprintf("%s/server_test.go", dir),
-			Content: []byte(fmt.Sprintf("package %s\n\nimport \"testing\"\n\nfunc TestRun(t *testing.T) {\n\tt.Log(\"test for %s server\")\n}\n", pkg, serviceName)),
+			Content: []byte(goLicenseHeader + fmt.Sprintf("package %s\n\nimport \"testing\"\n\nfunc TestRun(t *testing.T) {\n\tt.Log(\"test for %s server\")\n}\n", pkg, serviceName)),
 		})
 	}
 

--- a/internal/generation/adapters/go_test.go
+++ b/internal/generation/adapters/go_test.go
@@ -78,6 +78,15 @@ func TestGoAdapter_GenerateService(t *testing.T) {
 			if !strings.Contains(content, "api-gateway") {
 				t.Errorf("server.go should contain service name")
 			}
+			if !strings.Contains(content, "Copyright 2026 NAEOS Foundation") {
+				t.Errorf("server.go should include license header")
+			}
+		}
+		if strings.Contains(art.Path, "server_test.go") {
+			content := string(art.Content)
+			if !strings.Contains(content, "Copyright 2026 NAEOS Foundation") {
+				t.Errorf("server_test.go should include license header")
+			}
 		}
 	}
 	if !found {

--- a/internal/generation/engine/engine.go
+++ b/internal/generation/engine/engine.go
@@ -22,6 +22,14 @@ type Artifact struct {
 	Content []byte
 }
 
+const goLicenseHeader = `// Copyright 2026 NAEOS Foundation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+`
+
 type DefaultEngine struct{}
 
 func NewEngine() GeneratorEngine {
@@ -237,7 +245,7 @@ edition = "2021"
 func generateMainFile(lang language.Language, projectName string) string {
 	switch lang {
 	case language.LanguageGo:
-		return fmt.Sprintf("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello from %s\")\n}\n", projectName)
+		return goLicenseHeader + fmt.Sprintf("package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello from %s\")\n}\n", projectName)
 	case language.LanguageTypeScript:
 		return fmt.Sprintf("console.log('hello from %s');\n", projectName)
 	case language.LanguagePython:
@@ -272,7 +280,7 @@ func generateModuleFile(lang language.Language, moduleName, projectName string) 
 	pkg := strutil.Slugify(moduleName)
 	switch lang {
 	case language.LanguageGo:
-		return fmt.Sprintf("package %s\n\n// %s module.\n", pkg, moduleName)
+		return goLicenseHeader + fmt.Sprintf("package %s\n\n// %s module.\n", pkg, moduleName)
 	case language.LanguageTypeScript:
 		return fmt.Sprintf("// %s module\nexport {};\n", moduleName)
 	case language.LanguagePython:

--- a/internal/generation/engine/engine_test.go
+++ b/internal/generation/engine/engine_test.go
@@ -89,6 +89,34 @@ func TestGenerateForLanguageGo(t *testing.T) {
 	}
 }
 
+func TestGenerateForLanguageGoIncludesLicenseHeader(t *testing.T) {
+	neir := &model.NEIR{
+		Project: &project.Project{Name: "acme-api"},
+		Modules: []module.Module{{Name: "auth", Path: "./internal/auth"}},
+	}
+
+	engine := NewEngine()
+	artifacts, err := engine.GenerateForLanguage(neir, language.LanguageGo)
+	if err != nil {
+		t.Fatalf("GenerateForLanguage returned error: %v", err)
+	}
+	if len(artifacts) == 0 {
+		t.Fatal("expected artifacts from Go generation")
+	}
+
+	for _, a := range artifacts {
+		if strings.HasSuffix(a.Path, ".go") {
+			content := string(a.Content)
+			if !strings.Contains(content, "Copyright 2026 NAEOS Foundation") {
+				t.Errorf("expected license header in %s", a.Path)
+			}
+			if !strings.Contains(content, "package ") {
+				t.Errorf("expected package declaration in %s", a.Path)
+			}
+		}
+	}
+}
+
 func TestGenerateForLanguageTypeScript(t *testing.T) {
 	neir := &model.NEIR{
 		Project: &project.Project{Name: "web-app"},

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/NAEOS-foundation/naeos/internal/generation/adapters"
@@ -21,10 +22,10 @@ import (
 	"github.com/NAEOS-foundation/naeos/internal/planner/graph"
 	"github.com/NAEOS-foundation/naeos/internal/planner/scheduler"
 	"github.com/NAEOS-foundation/naeos/internal/registry"
+	naeoslog "github.com/NAEOS-foundation/naeos/internal/shared/log"
 	"github.com/NAEOS-foundation/naeos/internal/specification/normalizer"
 	"github.com/NAEOS-foundation/naeos/internal/specification/parser"
 	"github.com/NAEOS-foundation/naeos/internal/specification/resolver"
-	naeoslog "github.com/NAEOS-foundation/naeos/internal/shared/log"
 	cfgpkg "github.com/NAEOS-foundation/naeos/pkg/config"
 	"github.com/NAEOS-foundation/naeos/pkg/kernel"
 	"golang.org/x/sync/errgroup"
@@ -65,10 +66,10 @@ type HookContext struct {
 }
 
 type Hooks struct {
-	BeforeParse  []HookFunc
-	AfterParse   []HookFunc
-	BeforeRun    []HookFunc
-	AfterRun     []HookFunc
+	BeforeParse    []HookFunc
+	AfterParse     []HookFunc
+	BeforeRun      []HookFunc
+	AfterRun       []HookFunc
 	BeforeGenerate []HookFunc
 	AfterGenerate  []HookFunc
 }
@@ -200,6 +201,13 @@ func New(cfg Config) (*Pipeline, error) { //nolint:gocritic // Public API, value
 	}
 
 	return p, nil
+}
+
+func reviewRulesForArtifact(path string) []string {
+	if strings.HasSuffix(path, ".go") {
+		return []string{"no-todo", "no-placeholder", "has-package-declaration", "has-license-header"}
+	}
+	return []string{"no-todo", "no-placeholder"}
 }
 
 func (p *Pipeline) Name() string {
@@ -639,7 +647,8 @@ func (p *Pipeline) RunContext(ctx context.Context, input string) (*Result, error
 		p.logVerbose("reviewing %d artifacts", len(artifacts))
 		var reviews []*review.ReviewResult
 		for _, artifact := range artifacts {
-			r, err := p.reviewer.ReviewArtifact(artifact.Path, string(artifact.Content), []string{"no-todo", "no-placeholder"})
+			rules := reviewRulesForArtifact(artifact.Path)
+			r, err := p.reviewer.ReviewArtifact(artifact.Path, string(artifact.Content), rules)
 			if err == nil && r != nil {
 				reviews = append(reviews, r)
 			}

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NAEOS-foundation/naeos/internal/governance/review"
 	"github.com/NAEOS-foundation/naeos/internal/specification/parser"
 )
 
@@ -239,6 +240,59 @@ func TestPipelineRunWithSpecFullExample(t *testing.T) {
 	}
 	if tsArtifacts == 0 {
 		t.Fatal("expected TypeScript artifacts from spec-full.yaml generation")
+	}
+}
+
+func TestReviewRulesForArtifactGo(t *testing.T) {
+	goRules := reviewRulesForArtifact("src/main.go")
+	if len(goRules) != 4 {
+		t.Fatalf("expected 4 review rules for Go artifact, got %d", len(goRules))
+	}
+	expected := []string{"no-todo", "no-placeholder", "has-package-declaration", "has-license-header"}
+	for i, rule := range expected {
+		if goRules[i] != rule {
+			t.Fatalf("expected rule %q at index %d, got %q", rule, i, goRules[i])
+		}
+	}
+
+	nonGoRules := reviewRulesForArtifact("README.md")
+	if len(nonGoRules) != 2 {
+		t.Fatalf("expected 2 review rules for non-Go artifact, got %d", len(nonGoRules))
+	}
+	if nonGoRules[0] != "no-todo" || nonGoRules[1] != "no-placeholder" {
+		t.Fatalf("unexpected non-Go review rules: %#v", nonGoRules)
+	}
+}
+
+func TestPipelineRunWithGoReviewArtifacts(t *testing.T) {
+	p, err := New(Config{Languages: []string{"go"}})
+	if err != nil {
+		t.Fatalf("create pipeline failed: %v", err)
+	}
+
+	spec := `project: review-go
+services:
+  - name: api
+    kind: http
+    port: 8080
+`
+
+	result, err := p.Run(spec)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(result.Reviews) == 0 {
+		t.Fatal("expected review results")
+	}
+
+	approved := 0
+	for _, r := range result.Reviews {
+		if r.Status == review.StatusApproved {
+			approved++
+		}
+	}
+	if approved == 0 {
+		t.Fatal("expected at least one approved review")
 	}
 }
 


### PR DESCRIPTION
This PR adds Go license header generation for generated Go artifacts and extends pipeline review rule selection for Go files.

Changes include:
- Add Apache 2.0 license header support in Go adapter-generated artifacts and engine-generated Go files
- Apply Go-specific governance review rules for `.go` artifacts
- Add regression tests for generated Go service files including license header checks
