### PR TITLE
fix: add netlify.toml for Hugo build configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,17 @@
+[build]
+  base    = "site/"
+  publish = "public"
+  command = "hugo --minify"
+
+[build.environment]
+  HUGO_VERSION = "0.145.0"
+  HUGO_EXTENDED = "true"
+
+[context.production]
+  environment = { HUGO_ENV = "production" }
+
+[context.deploy-preview]
+  environment = { HUGO_ENV = "production" }
+
+[context.branch-deploy]
+  environment = { HUGO_ENV = "production" }


### PR DESCRIPTION
Adds `netlify.toml` so Netlify deploy preview knows how to build the Hugo site properly.

**Config:**
- Base directory: `site/`
- Build command: `hugo --minify`
- Publish directory: `public`
- Hugo version: `0.145.0` (extended)

This should fix the failing Netlify deploy preview checks on PRs.

Closes the Netlify deploy failure issue.