### PR TITLE
Phase 2: Interactive playground with xterm.js + WebSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ site/public/
 documentation.o
 cmd/naeos/nonexistent/
 internal/api/.naeos/
+naeos-demo

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -17,7 +17,7 @@
 | Wiki → Hugo migration ✅ | Site | Semua halaman wiki sudah dimigrasi ke Hugo site. Wiki/ dihapus. |
 | API docs auto-generate | Site | CI job baca `docs/openapi.yaml` → generate Swagger UI page di `/docs/api/` |
 | Blog content pipeline | Site | GitHub Action: detect release tag → auto-create blog post dari changelog |
-| Interactive playground | Site | Integrasi xterm.js + WebSocket ke server demo di homepage |
+| Interactive playground ✅ | Site | xterm.js + WebSocket ke server demo di homepage. Hero terminal interaktif, fallback ke animasi statis. Demo server di `cmd/naeos-demo/` |
 | PDF generation ✅ | Site | CLI reference + getting-started sebagai PDF download via GitHub Action (`pdf-docs.yml`). Tersedia di `/downloads/` |
 | Dark mode OG image | Site | Generate PNG OG image yang sesuai dark theme + light theme |
 

--- a/cmd/naeos-demo/main.go
+++ b/cmd/naeos-demo/main.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	addr      = flag.String("addr", ":9090", "listen address")
+	binary    = flag.String("binary", "naeos", "path to naeos binary")
+	maxSess   = flag.Int("max-sessions", 10, "max concurrent sessions")
+	sessTTL   = flag.Duration("session-ttl", 5*time.Minute, "session idle timeout")
+	allowOrig = flag.String("allow-origin", "*", "allowed origin (or * for all)")
+	whitelist = flag.String("whitelist", "init,validate,compile,run,version,help,spec", "comma-separated allowed subcommands")
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin: func(r *http.Request) bool {
+		if *allowOrig == "*" {
+			return true
+		}
+		origin := r.Header.Get("Origin")
+		return origin == *allowOrig || strings.HasPrefix(origin, *allowOrig)
+	},
+}
+
+type session struct {
+	id      string
+	dir     string
+	lastUse time.Time
+	cmd     *exec.Cmd
+	mu      sync.Mutex
+}
+
+type demoServer struct {
+	mu       sync.Mutex
+	sessions map[string]*session
+	naeosBin string
+	allowed  map[string]bool
+}
+
+func newDemoServer() *demoServer {
+	allowed := make(map[string]bool)
+	for _, s := range strings.Split(*whitelist, ",") {
+		allowed[strings.TrimSpace(s)] = true
+	}
+	return &demoServer{
+		sessions: make(map[string]*session),
+		naeosBin: *binary,
+		allowed:  allowed,
+	}
+}
+
+func (s *demoServer) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, sess := range s.sessions {
+		if time.Since(sess.lastUse) > *sessTTL {
+			sess.kill()
+			os.RemoveAll(sess.dir)
+			delete(s.sessions, id)
+		}
+	}
+}
+
+func (s *demoServer) createSession() (*session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.sessions) >= *maxSess {
+		for id, sess := range s.sessions {
+			if time.Since(sess.lastUse) > *sessTTL {
+				sess.kill()
+				os.RemoveAll(sess.dir)
+				delete(s.sessions, id)
+			}
+		}
+	}
+	if len(s.sessions) >= *maxSess {
+		return nil, fmt.Errorf("max sessions (%d) reached, try again later", *maxSess)
+	}
+
+	dir, err := os.MkdirTemp("", "naeos-demo-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	sess := &session{
+		id:      filepath.Base(dir),
+		dir:     dir,
+		lastUse: time.Now(),
+	}
+	s.sessions[sess.id] = sess
+	return sess, nil
+}
+
+func (sess *session) kill() {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if sess.cmd != nil && sess.cmd.Process != nil {
+		sess.cmd.Process.Kill()
+	}
+}
+
+func (sess *session) touch() {
+	sess.mu.Lock()
+	sess.lastUse = time.Now()
+	sess.mu.Unlock()
+}
+
+func (s *demoServer) handleWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("upgrade: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	sess, err := s.createSession()
+	if err != nil {
+		conn.WriteMessage(websocket.TextMessage, []byte("!error "+err.Error()))
+		return
+	}
+	defer func() {
+		sess.kill()
+		os.RemoveAll(sess.dir)
+		s.mu.Lock()
+		delete(s.sessions, sess.id)
+		s.mu.Unlock()
+	}()
+
+	conn.WriteMessage(websocket.TextMessage, []byte("!ready Session created in "+sess.dir))
+	conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		line := strings.TrimSpace(string(msg))
+		if line == "" {
+			continue
+		}
+
+		if line == "!reset" {
+			sess.kill()
+			newDir, err := os.MkdirTemp("", "naeos-demo-*")
+			if err != nil {
+				conn.WriteMessage(websocket.TextMessage, []byte("!error "+err.Error()))
+				continue
+			}
+			os.RemoveAll(sess.dir)
+			sess.dir = newDir
+			conn.WriteMessage(websocket.TextMessage, []byte("!ready Session reset"))
+			conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+			continue
+		}
+
+		sess.touch()
+
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+
+		if len(parts) >= 2 && parts[0] == "naeos" {
+			if !s.allowed[parts[1]] {
+				conn.WriteMessage(websocket.TextMessage, []byte("!error Command '"+parts[1]+"' not allowed in demo mode"))
+				conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+				continue
+			}
+			s.runCommand(conn, sess, parts[1:])
+		} else if parts[0] == "naeos" {
+			conn.WriteMessage(websocket.TextMessage, []byte("!error Usage: naeos <command> [args]"))
+			conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+		} else {
+			conn.WriteMessage(websocket.TextMessage, []byte("!error Unknown command. Try: naeos init, naeos validate, naeos compile"))
+			conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+		}
+	}
+}
+
+func (s *demoServer) runCommand(conn *websocket.Conn, sess *session, args []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.naeosBin, args...)
+	cmd.Dir = sess.dir
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		conn.WriteMessage(websocket.TextMessage, []byte("!error "+err.Error()))
+		conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		conn.WriteMessage(websocket.TextMessage, []byte("!error "+err.Error()))
+		conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+		return
+	}
+
+	sess.mu.Lock()
+	sess.cmd = cmd
+	sess.mu.Unlock()
+
+	if err := cmd.Start(); err != nil {
+		conn.WriteMessage(websocket.TextMessage, []byte("!error "+err.Error()))
+		conn.WriteMessage(websocket.TextMessage, []byte("!prompt"))
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := stdout.Read(buf)
+			if n > 0 {
+				conn.WriteMessage(websocket.TextMessage, buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderr.Read(buf)
+			if n > 0 {
+				conn.WriteMessage(websocket.TextMessage, buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	go func() {
+		cmd.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		conn.WriteMessage(websocket.TextMessage, []byte("\n!error Command timed out"))
+	}
+
+	conn.WriteMessage(websocket.TextMessage, []byte("\n!prompt"))
+}
+
+func main() {
+	flag.Parse()
+
+	if _, err := exec.LookPath(*binary); err != nil {
+		log.Printf("WARNING: naeos binary not found in PATH (%v). Demo will fail on command execution.", err)
+	}
+
+	server := newDemoServer()
+
+	go func() {
+		for range time.Tick(30 * time.Second) {
+			server.cleanup()
+		}
+	}()
+
+	http.HandleFunc("/ws", server.handleWS)
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	fmt.Printf("NAEOS Demo Server listening on %s\n", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -459,6 +459,12 @@ h4 { font-size: var(--font-size-base); }
 .terminal-line.output { color: var(--color-text-muted); }
 .terminal-line.output .highlight { color: var(--color-accent); }
 .terminal-cursor::after { content: '█'; animation: blink 1s step-end infinite; color: var(--color-accent); }
+#interactive-terminal .terminal-body { padding: 0; min-height: 280px; }
+#interactive-terminal .xterm { height: 100%; padding: 0.5rem; }
+#interactive-terminal .xterm-viewport { scrollbar-width: thin; scrollbar-color: var(--color-border) transparent; }
+#interactive-terminal .xterm-viewport::-webkit-scrollbar { width: 6px; }
+#interactive-terminal .xterm-viewport::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 3px; }
+#interactive-terminal .xterm-viewport::-webkit-scrollbar-track { background: transparent; }
 @keyframes terminalFadeIn { to { opacity: 1; } }
 @keyframes blink { 50% { opacity: 0; } }
 

--- a/site/assets/js/terminal.js
+++ b/site/assets/js/terminal.js
@@ -1,0 +1,222 @@
+(function () {
+  'use strict';
+
+  var wsUrl = window.NAEOS_WS_URL || '';
+  var container = document.getElementById('interactive-terminal');
+  if (!container || !wsUrl) return;
+
+  var term, fitAddon, ws, reconnectTimer;
+  var inputBuffer = '';
+  var history = [];
+  var historyIdx = -1;
+
+  function initTerminal() {
+    if (typeof Terminal === 'undefined') {
+      loadXterm();
+      return;
+    }
+
+    document.getElementById('hero-terminal-static').style.display = 'none';
+
+    term = new Terminal({
+      cursorBlink: true,
+      cursorStyle: 'block',
+      fontSize: 14,
+      fontFamily: "'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace",
+      theme: {
+        background: 'transparent',
+        foreground: '#e0e0e0',
+        cursor: '#00ff88',
+        cursorAccent: '#0a0a0a',
+        selectionBackground: 'rgba(0,255,136,0.3)',
+        black: '#1a1a1a',
+        red: '#ff4444',
+        green: '#00ff88',
+        yellow: '#ffaa00',
+        blue: '#569cd6',
+        magenta: '#c586c0',
+        cyan: '#4ec9b0',
+        white: '#e0e0e0',
+        brightBlack: '#666666',
+        brightRed: '#ff6666',
+        brightGreen: '#66ffaa',
+        brightYellow: '#ffbb33',
+        brightBlue: '#77b3e6',
+        brightMagenta: '#d499d4',
+        brightCyan: '#77d4c0',
+        brightWhite: '#ffffff',
+      },
+      allowTransparency: true,
+      convertEol: true,
+    });
+
+    fitAddon = new FitAddon.FitAddon();
+    term.loadAddon(fitAddon);
+
+    term.open(container);
+    fitAddon.fit();
+
+    window.addEventListener('resize', function () {
+      if (fitAddon) fitAddon.fit();
+    });
+
+    term.writeln('\x1b[32m▸ NAEOS Interactive Demo\x1b[0m');
+    term.writeln('\x1b[90m  Type \x1b[33mnaeos init\x1b[0m\x1b[90m to get started\x1b[0m');
+    term.writeln('');
+
+    setTimeout(connectWS, 500);
+  }
+
+  function loadXterm() {
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://cdn.jsdelivr.net/npm/xterm@5/css/xterm.min.css';
+    document.head.appendChild(link);
+
+    var script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/xterm@5/lib/xterm.min.js';
+    script.onload = function () {
+      var fitScript = document.createElement('script');
+      fitScript.src = 'https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8/lib/xterm-addon-fit.min.js';
+      fitScript.onload = initTerminal;
+      document.body.appendChild(fitScript);
+    };
+    document.body.appendChild(script);
+  }
+
+  function connectWS() {
+    if (ws && ws.readyState === WebSocket.OPEN) return;
+
+    term.writeln('\x1b[90mConnecting to demo server...\x1b[0m');
+
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch (e) {
+      term.writeln('\x1b[31mFailed to connect: ' + e.message + '\x1b[0m');
+      return;
+    }
+
+    ws.onopen = function () {
+      term.writeln('\x1b[32mConnected ✓\x1b[0m');
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      term.focus();
+    };
+
+    ws.onmessage = function (e) {
+      var data = e.data;
+      if (data.startsWith('!prompt')) {
+        writePrompt();
+      } else if (data.startsWith('!error ')) {
+        term.writeln('\x1b[31m' + data.substring(7) + '\x1b[0m');
+      } else if (data.startsWith('!ready ')) {
+        term.writeln('\x1b[90m' + data.substring(7) + '\x1b[0m');
+      } else {
+        term.write(data);
+      }
+    };
+
+    ws.onclose = function () {
+      if (term) {
+        term.writeln('');
+        term.writeln('\x1b[31mDisconnected from demo server\x1b[0m');
+        term.writeln('\x1b[90mReconnecting in 5s...\x1b[0m');
+      }
+      if (!reconnectTimer) {
+        reconnectTimer = setTimeout(function () {
+          reconnectTimer = null;
+          connectWS();
+        }, 5000);
+      }
+    };
+
+    ws.onerror = function () {
+      if (term) term.writeln('\x1b[31mConnection error\x1b[0m');
+    };
+  }
+
+  function writePrompt() {
+    term.write('\r\n\x1b[32m$\x1b[0m ');
+    inputBuffer = '';
+    historyIdx = -1;
+  }
+
+  term.onKey(function (e) {
+    var ev = e.domEvent;
+
+    if (ev.ctrlKey && ev.key === 'c') {
+      ws.send('\x03');
+      term.write('^C');
+      writePrompt();
+      return;
+    }
+
+    if (ev.key === 'Enter') {
+      if (inputBuffer.trim()) {
+        history.push(inputBuffer.trim());
+        if (history.length > 50) history.shift();
+      }
+      term.write('\r\n');
+      ws.send(inputBuffer);
+      inputBuffer = '';
+      return;
+    }
+
+    if (ev.key === 'Backspace') {
+      if (inputBuffer.length > 0) {
+        inputBuffer = inputBuffer.slice(0, -1);
+        term.write('\b \b');
+      }
+      return;
+    }
+
+    if (ev.key === 'ArrowUp') {
+      if (history.length > 0) {
+        var newIdx = historyIdx < 0 ? history.length - 1 : Math.max(0, historyIdx - 1);
+        if (newIdx !== historyIdx) {
+          while (inputBuffer.length > 0) {
+            term.write('\b \b');
+            inputBuffer = inputBuffer.slice(0, -1);
+          }
+          inputBuffer = history[newIdx];
+          term.write(inputBuffer);
+          historyIdx = newIdx;
+        }
+      }
+      return;
+    }
+
+    if (ev.key === 'ArrowDown') {
+      if (historyIdx >= 0) {
+        while (inputBuffer.length > 0) {
+          term.write('\b \b');
+          inputBuffer = inputBuffer.slice(0, -1);
+        }
+        if (historyIdx < history.length - 1) {
+          historyIdx++;
+          inputBuffer = history[historyIdx];
+          term.write(inputBuffer);
+        } else {
+          historyIdx = -1;
+        }
+      }
+      return;
+    }
+
+    if (ev.key === 'Tab') {
+      ev.preventDefault();
+      return;
+    }
+
+    if (e.key.length === 1 && !ev.ctrlKey && !ev.altKey && !ev.metaKey) {
+      inputBuffer += e.key;
+      term.write(e.key);
+    }
+  });
+
+  if (typeof Terminal !== 'undefined') {
+    initTerminal();
+  }
+})();

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -92,6 +92,8 @@ params:
     shortName: NAEOS
     backgroundColor: "#0a0a0a"
     themeColor: "#00ff88"
+  interactiveTerminal:
+    websocketUrl: wss://naeos-demo.fly.dev/ws
 
 permalinks:
   blog: /blog/:slug/

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -55,8 +55,13 @@
             success: {{ i18n "newsletter_success" | jsonify }},
             error: {{ i18n "newsletter_error" | jsonify }}
         };
+        {{ if .Site.Params.interactiveTerminal.websocketUrl }}
+        var NAEOS_WS_URL = '{{ .Site.Params.interactiveTerminal.websocketUrl }}';
+        {{ end }}
     </script>
     {{ $js := resources.Get "js/main.js" | resources.Minify | resources.Fingerprint "sha256" }}
     <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" defer></script>
+    {{ $termJs := resources.Get "js/terminal.js" | resources.Minify | resources.Fingerprint "sha256" }}
+    <script src="{{ $termJs.RelPermalink }}" integrity="{{ $termJs.Data.Integrity }}" defer></script>
 </body>
 </html>

--- a/site/layouts/partials/hero.html
+++ b/site/layouts/partials/hero.html
@@ -14,7 +14,7 @@
             <a href="{{ "docs/getting-started/" | relLangURL }}" class="btn btn-primary btn-lg">{{ i18n "cta_get_started" }}</a>
             <a href="{{ .Site.Params.social.github }}" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">{{ i18n "cta_view_on_github" }}</a>
         </div>
-        <div class="hero-terminal fade-in-scale">
+        <div class="hero-terminal fade-in-scale" id="hero-terminal-static">
             <div class="terminal-header">
                 <span class="terminal-dot red" aria-hidden="true"></span>
                 <span class="terminal-dot yellow" aria-hidden="true"></span>
@@ -37,6 +37,14 @@
                 <div class="terminal-line output">✓ Generated: go/, typescript/</div>
                 <div class="terminal-line output">✓ <span class="highlight">Done</span> in 1.2s</div>
                 <div class="terminal-line terminal-cursor"></div>
+            </div>
+        </div>
+        <div class="hero-terminal fade-in-scale" id="interactive-terminal" style="display:none;">
+            <div class="terminal-header">
+                <span class="terminal-dot red" aria-hidden="true"></span>
+                <span class="terminal-dot yellow" aria-hidden="true"></span>
+                <span class="terminal-dot green" aria-hidden="true"></span>
+                <span class="terminal-title">demo — naeos interactive</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

Adds interactive terminal playground to the homepage hero section.

### Backend
- **cmd/naeos-demo/**: standalone WebSocket demo server
  - Session isolation (temp dir per connection)
  - Command whitelist (`init`, `validate`, `compile`, `run`, `version`, `help`)
  - Rate limiting (max 10 concurrent sessions, 5min TTL, 30s command timeout)
  - Auto-cleanup of idle/stale sessions

### Frontend
- **xterm.js integration** on homepage hero
  - Loads xterm from CDN, connects to WebSocket demo server
  - Dark theme matching NAEOS brand
  - Command history (up/down arrows)
  - Reconnect on disconnect
  - Falls back to static terminal animation when WS URL not configured
- **CSS**: xterm.js dark theme with custom scrollbar styling

### Build
- `go build ./cmd/naeos-demo/` to build the demo server
- `naeos-demo -addr=:9090 -binary=./naeos` to run