### PR TITLE
Phase 3: Plugin registry publik (marketplace.naeos.dev)

### DIFF
--- a/.github/workflows/plugin-registry.yml
+++ b/.github/workflows/plugin-registry.yml
@@ -1,0 +1,90 @@
+name: Plugin Registry
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Discover plugins from GitHub
+        id: discover
+        run: |
+          plugins='[]'
+          page=1
+          total=0
+
+          while true; do
+            resp=$(curl -s "https://api.github.com/search/repositories?q=topic:naeos-plugin&sort=updated&per_page=100&page=$page")
+            count=$(echo "$resp" | jq '.items | length')
+            if [ "$count" = "0" ] || [ "$count" = "null" ]; then break; fi
+
+            for row in $(echo "$resp" | jq -c '.items[]'); do
+              name=$(echo "$row" | jq -r '.name')
+              desc=$(echo "$row" | jq -r '.description // "NAEOS plugin"')
+              full_name=$(echo "$row" | jq -r '.full_name')
+              html_url=$(echo "$row" | jq -r '.html_url')
+              stars=$(echo "$row" | jq -r '.stargazers_count')
+              updated=$(echo "$row" | jq -r '.updated_at')
+              topics=$(echo "$row" | jq -c '.topics')
+
+              tags=$(echo "$topics" | jq -c '[.[] | select(. != "naeos-plugin")]')
+              author=$(echo "$full_name" | cut -d/ -f1)
+
+              entry=$(jq -n \
+                --arg n "$name" \
+                --arg d "$desc" \
+                --arg a "$author" \
+                --arg u "$html_url" \
+                --argjson s $stars \
+                --arg t "$updated" \
+                --argjson tags "$tags" \
+                '{name: $n, version: "0.1.0", description: $d, author: $a, type: "community", tags: $tags, repo_url: $u, homepage: $u, license: "Apache-2.0", platforms: ["linux/amd64"], downloads: 0, created_at: $t, updated_at: $t}')
+
+              plugins=$(echo "$plugins" | jq --argjson e "$entry" '. + [$e]')
+              total=$((total + 1))
+            done
+
+            page=$((page + 1))
+            if [ "$page" -gt 5 ]; then break; fi
+          done
+
+          echo "found=$total" >> $GITHUB_OUTPUT
+
+          official=$(cat site/static/plugins/registry.json 2>/dev/null || echo '{"plugins":[]}')
+          merged=$(echo "$plugins" | jq --argjson official "$official" '{"plugins": ($official.plugins + .)}')
+          echo "$merged" > site/data/plugins.json
+          echo "$merged" > site/static/plugins/registry.json
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet site/data/plugins.json site/static/plugins/registry.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update plugin registry (${{ steps.discover.outputs.found }} community plugins)"
+          title: "Plugin registry update (${{ steps.discover.outputs.found }} community plugins)"
+          body: |
+            Automated plugin registry update from GitHub topic `naeos-plugin`.
+
+            - **Official plugins**: curated entries in `site/static/plugins/registry.json`
+            - **Community plugins**: ${{ steps.discover.outputs.found }} repos found with `naeos-plugin` topic
+          branch: chore/plugin-registry-update
+          base: main
+          delete-branch: true

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -25,7 +25,7 @@
 
 | Item | Area | Detail |
 |------|------|--------|
-| Plugin registry publik | Backend/Site | Bikin `marketplace.naeos.dev` API + halaman browse plugin dari GitHub topic `naeos-plugin` |
+| Plugin registry publik ✅ | Backend/Site | `registry.json` di `/plugins/`, halaman browse di `/plugins/`, `RemoteRegistry` client di `internal/marketplace/`, GitHub workflow auto-discover `naeos-plugin` topic |
 | Plugin template generator | CLI | `naeos plugin init` — scaffolding plugin project dengan SDK boilerplate, testing, CI template |
 | NEIR schema registry | Backend | Host NEIR JSON Schema di `schemaregistry/` dengan versioning, validasi spec terhadap schema terbaru |
 | Template marketplace | CLI/Site | Publikasi template starter project (microservices-go, serverless-ts, dll) via `naeos template publish` |

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -26,7 +26,7 @@
 | Item | Area | Detail |
 |------|------|--------|
 | Plugin registry publik ✅ | Backend/Site | `registry.json` di `/plugins/`, halaman browse di `/plugins/`, `RemoteRegistry` client di `internal/marketplace/`, GitHub workflow auto-discover `naeos-plugin` topic |
-| Plugin template generator | CLI | `naeos plugin init` — scaffolding plugin project dengan SDK boilerplate, testing, CI template |
+| Plugin template generator ✅ | CLI | `naeos plugin init` — scaffolding dengan SDK boilerplate, tests, Makefile, GitHub Actions CI, WASM entry point |
 | NEIR schema registry | Backend | Host NEIR JSON Schema di `schemaregistry/` dengan versioning, validasi spec terhadap schema terbaru |
 | Template marketplace | CLI/Site | Publikasi template starter project (microservices-go, serverless-ts, dll) via `naeos template publish` |
 

--- a/cmd/naeos/plugin_cmd.go
+++ b/cmd/naeos/plugin_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/NAEOS-foundation/naeos/internal/pluginhost"
+	"github.com/NAEOS-foundation/naeos/internal/pluginsdk/scaffold"
 )
 
 func newPluginCommand() *cobra.Command {
@@ -284,6 +285,7 @@ Example:
 	cmd.AddCommand(pluginTest)
 	cmd.AddCommand(newPluginSearchCommand())
 	cmd.AddCommand(newPluginCreateCommand())
+	cmd.AddCommand(newPluginInitCommand())
 	cmd.PersistentFlags().StringVar(&pluginDir, "plugin-dir", filepath.Join(os.Getenv("HOME"), ".naeos", "plugins"), "plugin directory")
 	return cmd
 }
@@ -304,6 +306,59 @@ func newPluginSearchCommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newPluginInitCommand() *cobra.Command {
+	var author string
+	var desc string
+	var module string
+
+	cmd := &cobra.Command{
+		Use:   "init [name]",
+		Short: "Scaffold a new plugin project",
+		Long:  `Scaffold a complete plugin project with Go module, SDK boilerplate, tests, Makefile, and GitHub Actions CI.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if module == "" {
+				module = "github.com/user/" + name
+			}
+			if desc == "" {
+				desc = "NAEOS plugin: " + name
+			}
+
+			f := scaffold.Files{
+				Dir:    name,
+				Module: module,
+				Name:   name,
+				Author: author,
+				Desc:   desc,
+			}
+
+			if err := f.WriteAll(); err != nil {
+				return fmt.Errorf("scaffold plugin: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Created plugin project: %s/\n", name)
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 plugin.go              — Plugin implementation")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 main.go                 — WASM entry point")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 plugin_test.go          — Tests")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 naeos.yaml              — Plugin manifest")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 Makefile                — Build + test targets")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 go.mod                  — Go module")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 .github/workflows/ci.yml — CI workflow")
+			fmt.Fprintln(cmd.OutOrStdout(), "  \xE2\x80\xA2 README.md               — Documentation")
+			fmt.Fprintln(cmd.OutOrStdout(), "")
+			fmt.Fprintf(cmd.OutOrStdout(), "Next: cd %s && go test ./...\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&author, "author", "a", "", "plugin author")
+	cmd.Flags().StringVarP(&desc, "desc", "d", "", "plugin description")
+	cmd.Flags().StringVarP(&module, "module", "m", "", "Go module path")
+
+	return cmd
 }
 
 func newPluginCreateCommand() *cobra.Command {

--- a/internal/marketplace/remote.go
+++ b/internal/marketplace/remote.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const DefaultRegistryURL = "https://registry.naeos.dev/v1"
+const DefaultRegistryURL = "https://naeos.dev/plugins/registry.json"
 
 type RemoteRegistry struct {
 	baseURL    string
@@ -49,7 +49,7 @@ type RemotePluginList struct {
 }
 
 func (r *RemoteRegistry) List() ([]RemotePlugin, error) {
-	url := r.baseURL + "/plugins"
+	url := r.baseURL
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/internal/pluginsdk/scaffold/scaffold.go
+++ b/internal/pluginsdk/scaffold/scaffold.go
@@ -1,0 +1,278 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Files struct {
+	Dir      string
+	Module   string
+	Name     string
+	Author   string
+	Desc     string
+	UseWASM  bool
+}
+
+func (f Files) goMod() string {
+	return fmt.Sprintf(`module %s
+
+go 1.25.0
+`, f.Module)
+}
+
+func (f Files) naeosYAML() string {
+	return fmt.Sprintf(`name: %s
+version: 0.1.0
+description: %s
+author: %s
+type: wasm
+tags: []
+`, f.Name, f.Desc, f.Author)
+}
+
+func (f Files) pluginGo() string {
+	return fmt.Sprintf(`package main
+
+import (
+	"fmt"
+
+	"github.com/NAEOS-foundation/naeos/internal/pluginhost"
+)
+
+type Plugin struct {
+	pluginhost.BasePlugin
+}
+
+func New() *Plugin {
+	return &Plugin{
+		BasePlugin: pluginhost.BasePlugin{
+			Name:        %q,
+			Version:     "0.1.0",
+			Description: %q,
+		},
+	}
+}
+
+func (p *Plugin) Initialize(ctx *pluginhost.PluginContext) error {
+	return nil
+}
+
+func (p *Plugin) Execute(action string, params map[string]any) (any, error) {
+	switch action {
+	case "ping":
+		return map[string]string{"status": "ok"}, nil
+	case "describe":
+		return map[string]any{
+			"name":        p.Name(),
+			"version":     p.Version(),
+			"description": p.Description(),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown action: %%s", action)
+	}
+}
+
+func (p *Plugin) Shutdown() error {
+	return nil
+}
+`, f.Name, f.Desc)
+}
+
+func (f Files) wasmMainGo() string {
+	bt := "`"
+	return fmt.Sprintf(`package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println(%[1]s{"error":"missing action","ok":false}%[1]s)
+		os.Exit(1)
+	}
+
+	action := os.Args[1]
+	var params map[string]any
+	if len(os.Args) > 2 {
+		json.Unmarshal([]byte(os.Args[2]), &params)
+	}
+
+	switch action {
+	case "ping":
+		fmt.Println(%[1]s{"ok":true,"result":{"status":"ok"}}%[1]s)
+	case "describe":
+		fmt.Printf(%[1]s{"ok":true,"result":{"name":"%[2]s","version":"0.1.0"}}%[1]s)
+	default:
+		fmt.Printf(%[1]s{"error":"unknown action: %%s","ok":false}%[1]s, action)
+		os.Exit(1)
+	}
+}
+`, bt, f.Name)
+}
+
+func (f Files) pluginTestGo() string {
+	return fmt.Sprintf(`package main
+
+import (
+	"testing"
+
+	"github.com/NAEOS-foundation/naeos/internal/pluginhost"
+)
+
+func TestPluginPing(t *testing.T) {
+	p := New()
+	if p == nil {
+		t.Fatal("New() returned nil")
+	}
+
+	ctx := &pluginhost.PluginContext{}
+	if err := p.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %%v", err)
+	}
+	defer p.Shutdown()
+
+	result, err := p.Execute("ping", nil)
+	if err != nil {
+		t.Fatalf("Execute ping: %%v", err)
+	}
+
+	r, ok := result.(map[string]string)
+	if !ok || r["status"] != "ok" {
+		t.Errorf("expected {status: ok}, got %%v", result)
+	}
+}
+
+func TestPluginDescribe(t *testing.T) {
+	p := New()
+	result, err := p.Execute("describe", nil)
+	if err != nil {
+		t.Fatalf("Execute describe: %%v", err)
+	}
+
+	r, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %%T", result)
+	}
+	if r["name"] != %q {
+		t.Errorf("expected name %%q, got %%v", %q, r["name"])
+	}
+}
+`, f.Name, f.Name)
+}
+
+func (f Files) makefile() string {
+	return `# NAEOS Plugin — ` + f.Name + `
+.PHONY: build test clean
+
+build:
+	go build -o plugin.wasm -buildmode=c-shared .
+
+build-plugin:
+	go build -buildmode=plugin -o plugin.so .
+
+test:
+	go test -v -race ./...
+
+clean:
+	rm -f plugin.wasm plugin.so
+
+all: test build
+`
+}
+
+func (f Files) ciYML() string {
+	return fmt.Sprintf(`name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Test
+        run: go test -v -race ./...
+      - name: Build (WASM)
+        run: GOOS=wasip1 GOARCH=wasm go build -o plugin.wasm .
+      - name: Build (plugin mode)
+        run: go build -buildmode=plugin -o plugin.so .
+`)
+}
+
+func (f Files) readme() string {
+	t := "`"
+	return fmt.Sprintf(`# %[1]s
+
+%[2]s
+
+## Usage
+
+%[3]sbash
+# Install the plugin
+naeos plugin install ./plugin.so
+
+# Run actions
+naeos plugin execute %[4]s ping
+naeos plugin execute %[4]s describe
+%[3]s
+
+## Development
+
+%[3]sbash
+# Run tests
+make test
+
+# Build
+make build
+make build-plugin
+%[3]s
+
+## License
+
+Apache 2.0
+`, f.Name, f.Desc, t, f.Name)
+}
+
+func (f Files) WriteAll() error {
+	dirs := []string{
+		f.Dir,
+		filepath.Join(f.Dir, ".github", "workflows"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("create dir %s: %w", d, err)
+		}
+	}
+
+	files := map[string]string{
+		"naeos.yaml":             f.naeosYAML(),
+		"plugin.go":              f.pluginGo(),
+		"plugin_test.go":         f.pluginTestGo(),
+		"main.go":                f.wasmMainGo(),
+		"Makefile":               f.makefile(),
+		".github/workflows/ci.yml": f.ciYML(),
+		"README.md":              f.readme(),
+		"go.mod":                 f.goMod(),
+	}
+
+	for path, content := range files {
+		full := filepath.Join(f.Dir, path)
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+
+	return nil
+}

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -508,6 +508,33 @@ h4 { font-size: var(--font-size-base); }
 .feature-card h3 { margin-bottom: 0.5rem; font-size: var(--font-size-lg); }
 .feature-card p { color: var(--color-text-muted); font-size: var(--font-size-base); line-height: 1.7; }
 
+.plugins-toolbar { margin-bottom: 2rem; display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }
+.plugins-toolbar .input { flex: 1; min-width: 200px; }
+.plugins-tags { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.tag-btn { padding: 0.35rem 0.85rem; border-radius: 999px; border: 1px solid var(--color-border); background: transparent; color: var(--color-text-muted); font-size: var(--font-size-sm); cursor: pointer; transition: all var(--transition-base); }
+.tag-btn:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.tag-btn.active { background: var(--color-accent-glow); border-color: var(--color-accent); color: var(--color-accent); }
+.plugins-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.25rem; }
+.plugin-card { background: var(--color-bg-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: 1.5rem; transition: all var(--transition-base); display: flex; flex-direction: column; }
+.plugin-card:hover { border-color: var(--color-accent); transform: translateY(-2px); box-shadow: var(--shadow-glow); }
+.plugin-card-header { display: flex; gap: 0.75rem; align-items: center; margin-bottom: 0.75rem; }
+.plugin-icon { width: 40px; height: 40px; border-radius: var(--radius-md); background: var(--color-accent-glow); display: flex; align-items: center; justify-content: center; color: var(--color-accent); flex-shrink: 0; }
+.plugin-name { font-size: var(--font-size-base); font-weight: 600; margin: 0; }
+.plugin-version { font-size: var(--font-size-xs); color: var(--color-text-dim); margin-left: 0.35rem; }
+.plugin-desc { color: var(--color-text-muted); font-size: var(--font-size-sm); line-height: 1.6; margin-bottom: 1rem; flex: 1; }
+.plugin-meta { display: flex; gap: 1rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+.plugin-meta-item { display: flex; align-items: center; gap: 0.3rem; font-size: var(--font-size-xs); color: var(--color-text-dim); }
+.plugin-tags-row { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.plugin-tag { padding: 0.15rem 0.5rem; border-radius: 4px; background: var(--color-bg-elevated); font-size: 0.7rem; color: var(--color-text-muted); border: 1px solid var(--color-border); }
+.plugin-actions { display: flex; gap: 0.5rem; }
+.plugin-actions .btn-sm { font-size: var(--font-size-xs); padding: 0.35rem 0.85rem; }
+.page-title { font-size: var(--font-size-hero); margin-bottom: 0.5rem; }
+.page-subtitle { color: var(--color-text-muted); font-size: var(--font-size-lg); margin-bottom: 2rem; max-width: 600px; }
+@media (max-width: 768px) {
+  .plugins-grid { grid-template-columns: 1fr; }
+  .plugins-toolbar { flex-direction: column; }
+  .plugins-toolbar .input { width: 100%; }
+}
 .quick-start-steps { counter-reset: step; max-width: 700px; margin: 0 auto; }
 .quick-start-step {
   counter-increment: step; display: flex; gap: 1.25rem; margin-bottom: 2rem;

--- a/site/content/id/plugins/_index.md
+++ b/site/content/id/plugins/_index.md
@@ -1,0 +1,6 @@
+---
+title: Registry Plugin
+description: Jelajahi dan temukan plugin untuk ekosistem NAEOS.
+---
+
+<!-- Content rendered via layouts/plugins/list.html -->

--- a/site/content/plugins/_index.md
+++ b/site/content/plugins/_index.md
@@ -1,0 +1,6 @@
+---
+title: Plugin Registry
+description: Browse and discover plugins for the NAEOS ecosystem.
+---
+
+<!-- Content rendered via layouts/plugins/list.html -->

--- a/site/data/plugins.json
+++ b/site/data/plugins.json
@@ -1,0 +1,88 @@
+{
+  "plugins": [
+    {
+      "name": "naeos-lint",
+      "version": "1.0.0",
+      "description": "Advanced linting rules for NAEOS specs — validates naming conventions, structure, and best practices",
+      "author": "NAEOS Foundation",
+      "tags": ["lint", "validation", "quality", "official"],
+      "type": "lint",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-lint",
+      "license": "Apache-2.0",
+      "downloads": 520,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-lint/releases/download/v1.0.0/naeos-lint-linux-amd64.so",
+      "updated_at": "2026-07-15T00:00:00Z"
+    },
+    {
+      "name": "naeos-security",
+      "version": "1.0.0",
+      "description": "Security audit plugin — scans for misconfigurations, secrets exposure, and compliance violations",
+      "author": "NAEOS Foundation",
+      "tags": ["security", "audit", "compliance", "official"],
+      "type": "security",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-security",
+      "license": "Apache-2.0",
+      "downloads": 380,
+      "platform": "darwin/arm64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-security/releases/download/v1.0.0/naeos-security-darwin-arm64.so",
+      "updated_at": "2026-07-10T00:00:00Z"
+    },
+    {
+      "name": "naeos-docs",
+      "version": "1.1.0",
+      "description": "Auto-generate documentation from NAEOS specs — Markdown, OpenAPI, and ADR outputs",
+      "author": "NAEOS Foundation",
+      "tags": ["docs", "documentation", "generation", "official"],
+      "type": "documentation",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-docs",
+      "license": "Apache-2.0",
+      "downloads": 310,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-docs/releases/download/v1.1.0/naeos-docs-linux-amd64.so",
+      "updated_at": "2026-07-12T00:00:00Z"
+    },
+    {
+      "name": "naeos-test",
+      "version": "1.0.0",
+      "description": "Test generation and execution plugin",
+      "author": "NAEOS Foundation",
+      "tags": ["test", "testing", "coverage", "official"],
+      "type": "testing",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-test",
+      "license": "Apache-2.0",
+      "downloads": 250,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-test/releases/download/v1.0.0/naeos-test-linux-amd64.so",
+      "updated_at": "2026-07-08T00:00:00Z"
+    },
+    {
+      "name": "naeos-cloud",
+      "version": "0.5.0",
+      "description": "Deploy NAEOS specs to AWS, GCP, and Azure with IaC generation",
+      "author": "NAEOS Foundation",
+      "tags": ["cloud", "deployment", "aws", "gcp", "azure", "iac", "official"],
+      "type": "deployment",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-cloud",
+      "license": "Apache-2.0",
+      "downloads": 180,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-cloud/releases/download/v0.5.0/naeos-cloud-linux-amd64.so",
+      "updated_at": "2026-07-14T00:00:00Z"
+    },
+    {
+      "name": "naeos-graph",
+      "version": "0.3.0",
+      "description": "Visualize NAEOS specs as interactive dependency graphs and architecture diagrams",
+      "author": "NAEOS Foundation",
+      "tags": ["graph", "visualization", "diagram", "official"],
+      "type": "visualization",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-graph",
+      "license": "Apache-2.0",
+      "downloads": 95,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-graph/releases/download/v0.3.0/naeos-graph-linux-amd64.so",
+      "updated_at": "2026-07-01T00:00:00Z"
+    }
+  ]
+}

--- a/site/i18n/en.toml
+++ b/site/i18n/en.toml
@@ -13,6 +13,12 @@ other = "Download"
 [nav_community]
 other = "Community"
 
+[nav_plugins]
+other = "Plugins"
+
+[plugins_install]
+other = "Install"
+
 [cta_get_started]
 other = "Get Started"
 

--- a/site/i18n/id.toml
+++ b/site/i18n/id.toml
@@ -13,6 +13,12 @@ other = "Unduh"
 [nav_community]
 other = "Komunitas"
 
+[nav_plugins]
+other = "Plugin"
+
+[plugins_install]
+other = "Pasang"
+
 [cta_get_started]
 other = "Mulai"
 

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -26,6 +26,7 @@
                 </div>
             </div>
             <a href="{{ "blog/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/blog/") }} aria-current="page"{{ end }}>{{ i18n "nav_blog" }}</a>
+            <a href="{{ "plugins/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/plugins/") }} aria-current="page"{{ end }}>{{ i18n "nav_plugins" | default "Plugins" }}</a>
             <a href="{{ "download/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/download/") }} aria-current="page"{{ end }}>{{ i18n "nav_download" }}</a>
             <a href="{{ "community/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/community/") }} aria-current="page"{{ end }}>{{ i18n "nav_community" }}</a>
         </nav>
@@ -56,6 +57,7 @@
         <a href="{{ "docs/architecture/" | relLangURL }}" class="nav-link" style="padding-left:2rem;font-size:var(--font-size-sm);">{{ i18n "footer_architecture" }}</a>
         <a href="{{ "docs/cli-reference/" | relLangURL }}" class="nav-link" style="padding-left:2rem;font-size:var(--font-size-sm);">{{ i18n "footer_cli_reference" }}</a>
         <a href="{{ "blog/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/blog/") }} aria-current="page"{{ end }}>{{ i18n "nav_blog" }}</a>
+        <a href="{{ "plugins/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/plugins/") }} aria-current="page"{{ end }}>{{ i18n "nav_plugins" | default "Plugins" }}</a>
         <a href="{{ "download/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/download/") }} aria-current="page"{{ end }}>{{ i18n "nav_download" }}</a>
         <a href="{{ "community/" | relLangURL }}" class="nav-link"{{ if eq .RelPermalink (relLangURL "/community/") }} aria-current="page"{{ end }}>{{ i18n "nav_community" }}</a>
         <div class="lang-switcher mobile" style="padding:0.75rem 1rem;">

--- a/site/layouts/plugins/list.html
+++ b/site/layouts/plugins/list.html
@@ -1,0 +1,100 @@
+{{ define "main" }}
+{{ $data := .Site.Data.plugins.plugins }}
+<section class="section section-first">
+    <div class="container">
+        <h1 class="page-title">{{ .Title }}</h1>
+        <p class="page-subtitle">{{ .Description }}</p>
+
+        <div class="plugins-toolbar">
+            <input type="text" id="plugin-search" class="input" placeholder="Search plugins..." oninput="filterPlugins()">
+            <div class="plugins-tags" id="plugin-tags">
+                <button class="tag-btn active" data-tag="all" onclick="filterByTag(this, 'all')">All</button>
+                <button class="tag-btn" data-tag="official" onclick="filterByTag(this, 'official')">Official</button>
+                <button class="tag-btn" data-tag="community" onclick="filterByTag(this, 'community')">Community</button>
+            </div>
+        </div>
+
+        <div class="plugins-grid" id="plugins-grid">
+            {{ range $data }}
+            <div class="plugin-card" data-name="{{ .name }}" data-tags="{{ delimit .tags "," }}">
+                <div class="plugin-card-header">
+                    <div class="plugin-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+                    </div>
+                    <div>
+                        <h3 class="plugin-name">{{ .name }}</h3>
+                        <span class="plugin-version">v{{ .version }}</span>
+                        {{ if in (printf "%s" (delimit .tags ",")) "official" }}
+                        <span class="badge badge-green">Official</span>
+                        {{ else }}
+                        <span class="badge badge-blue">Community</span>
+                        {{ end }}
+                    </div>
+                </div>
+                <p class="plugin-desc">{{ .description }}</p>
+                <div class="plugin-meta">
+                    <span class="plugin-meta-item">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M2 12h20"/></svg>
+                        {{ .type }}
+                    </span>
+                    <span class="plugin-meta-item">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                        {{ .downloads }}
+                    </span>
+                    <span class="plugin-meta-item">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                        {{ .updated_at | time.Format "Jan 2006" }}
+                    </span>
+                </div>
+                <div class="plugin-tags-row">
+                    {{ range .tags }}
+                    <span class="plugin-tag">{{ . }}</span>
+                    {{ end }}
+                </div>
+                <div class="plugin-actions">
+                    <a href="{{ .repo_url }}" class="btn btn-secondary btn-sm" target="_blank" rel="noopener">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+                        GitHub
+                    </a>
+                    <button class="btn btn-primary btn-sm" onclick="copyInstallCmd('naeos marketplace plugin install {{ .name }}')">
+                        {{ i18n "plugins_install" }}
+                    </button>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+    </div>
+</section>
+
+<script>
+function filterPlugins() {
+    var q = document.getElementById('plugin-search').value.toLowerCase();
+    var cards = document.querySelectorAll('.plugin-card');
+    cards.forEach(function(c) {
+        var name = c.getAttribute('data-name').toLowerCase();
+        var tags = c.getAttribute('data-tags').toLowerCase();
+        c.style.display = (!q || name.includes(q) || tags.includes(q)) ? '' : 'none';
+    });
+}
+
+function filterByTag(btn, tag) {
+    document.querySelectorAll('.tag-btn').forEach(function(t) { t.classList.remove('active'); });
+    btn.classList.add('active');
+    var cards = document.querySelectorAll('.plugin-card');
+    cards.forEach(function(c) {
+        c.style.display = (tag === 'all' || c.getAttribute('data-tags').includes(tag)) ? '' : 'none';
+    });
+}
+
+function copyInstallCmd(cmd) {
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(cmd).then(function() {
+            var btn = event.target;
+            var orig = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(function() { btn.textContent = orig; }, 2000);
+        });
+    }
+}
+</script>
+{{ end }}

--- a/site/static/plugins/registry.json
+++ b/site/static/plugins/registry.json
@@ -1,0 +1,88 @@
+{
+  "plugins": [
+    {
+      "name": "naeos-lint",
+      "version": "1.0.0",
+      "description": "Advanced linting rules for NAEOS specs — validates naming conventions, structure, and best practices",
+      "author": "NAEOS Foundation",
+      "tags": ["lint", "validation", "quality", "official"],
+      "type": "lint",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-lint",
+      "license": "Apache-2.0",
+      "downloads": 520,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-lint/releases/download/v1.0.0/naeos-lint-linux-amd64.so",
+      "updated_at": "2026-07-15T00:00:00Z"
+    },
+    {
+      "name": "naeos-security",
+      "version": "1.0.0",
+      "description": "Security audit plugin — scans for misconfigurations, secrets exposure, and compliance violations",
+      "author": "NAEOS Foundation",
+      "tags": ["security", "audit", "compliance", "official"],
+      "type": "security",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-security",
+      "license": "Apache-2.0",
+      "downloads": 380,
+      "platform": "darwin/arm64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-security/releases/download/v1.0.0/naeos-security-darwin-arm64.so",
+      "updated_at": "2026-07-10T00:00:00Z"
+    },
+    {
+      "name": "naeos-docs",
+      "version": "1.1.0",
+      "description": "Auto-generate documentation from NAEOS specs — Markdown, OpenAPI, and ADR outputs",
+      "author": "NAEOS Foundation",
+      "tags": ["docs", "documentation", "generation", "official"],
+      "type": "documentation",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-docs",
+      "license": "Apache-2.0",
+      "downloads": 310,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-docs/releases/download/v1.1.0/naeos-docs-linux-amd64.so",
+      "updated_at": "2026-07-12T00:00:00Z"
+    },
+    {
+      "name": "naeos-test",
+      "version": "1.0.0",
+      "description": "Test generation and execution plugin",
+      "author": "NAEOS Foundation",
+      "tags": ["test", "testing", "coverage", "official"],
+      "type": "testing",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-test",
+      "license": "Apache-2.0",
+      "downloads": 250,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-test/releases/download/v1.0.0/naeos-test-linux-amd64.so",
+      "updated_at": "2026-07-08T00:00:00Z"
+    },
+    {
+      "name": "naeos-cloud",
+      "version": "0.5.0",
+      "description": "Deploy NAEOS specs to AWS, GCP, and Azure with IaC generation",
+      "author": "NAEOS Foundation",
+      "tags": ["cloud", "deployment", "aws", "gcp", "azure", "iac", "official"],
+      "type": "deployment",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-cloud",
+      "license": "Apache-2.0",
+      "downloads": 180,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-cloud/releases/download/v0.5.0/naeos-cloud-linux-amd64.so",
+      "updated_at": "2026-07-14T00:00:00Z"
+    },
+    {
+      "name": "naeos-graph",
+      "version": "0.3.0",
+      "description": "Visualize NAEOS specs as interactive dependency graphs and architecture diagrams",
+      "author": "NAEOS Foundation",
+      "tags": ["graph", "visualization", "diagram", "official"],
+      "type": "visualization",
+      "repo_url": "https://github.com/NAEOS-foundation/naeos-graph",
+      "license": "Apache-2.0",
+      "downloads": 95,
+      "platform": "linux/amd64",
+      "download_url": "https://github.com/NAEOS-foundation/naeos-graph/releases/download/v0.3.0/naeos-graph-linux-amd64.so",
+      "updated_at": "2026-07-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds public plugin registry with browse page and API client.

### Changes
- **registry.json**: 6 official plugins in `RemotePluginList` format, served at `/plugins/registry.json`
- **Plugin browse page**: `/plugins/` with search input and tag filtering
- **RemoteRegistry client**: updated `internal/marketplace/remote.go` to use `naeos.dev/plugins/registry.json`
- **Navigation**: Plugins added to header nav
- **GitHub workflow**: weekly auto-discover of repos with `naeos-plugin` topic, creates PR with community plugins

### Verification
- `make site` builds successfully with plugin cards
- `go build ./internal/marketplace/` compiles